### PR TITLE
🐛Fix: 폼 의존성 배열 개선

### DIFF
--- a/app/(team)/[id]/_component/Report.tsx
+++ b/app/(team)/[id]/_component/Report.tsx
@@ -16,7 +16,7 @@ function Report() {
 	const groupId = Array.isArray(id) ? id[0] : id;
 
 	const fetchGroupInfo = useCallback((): Promise<Team> => API["{teamId}/groups/{id}"]
-		.GET({ id: groupId })
+		.GET({ id: Number(groupId) })
 		.then((response) => response)
 		.catch((error) => {
 			console.error("그룹 정보 조회 실패:", error);

--- a/app/_components/Form.tsx
+++ b/app/_components/Form.tsx
@@ -181,7 +181,7 @@ Form.Input = function Input({
 		// you've made all the way through here..! congrats
 		ctx.setError(id, OK);
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [value, focus, tests, ctx.values]);
+	}, [value, focus, ctx.values, JSON.stringify(tests)]);
 
 	const self = useRef<HTMLDivElement>(null);
 
@@ -241,7 +241,7 @@ Form.Input = function Input({
 };
 
 Form.TextArea = function TextArea({ id, init, tests, placeholder }: Readonly<{ id: string; init?: string; tests?: Validator[]; placeholder?: string }>) {
-	const ctx = uinseCTX();
+	const ctx = useCTX();
 
 	const [value, setValue] = useState("");
 	const [focus, setFocus] = useState(false);
@@ -305,7 +305,7 @@ Form.TextArea = function TextArea({ id, init, tests, placeholder }: Readonly<{ i
 		// you've made all the way through here..! congrats
 		ctx.setError(id, OK);
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [value, focus, tests, ctx.values]);
+	}, [value, focus, ctx.values, JSON.stringify(tests)]);
 
 	const self = useRef<HTMLTextAreaElement>(null);
 
@@ -416,7 +416,7 @@ Form.ImageInput = function ImageInput({
 		// you've made all the way through here..! congrats
 		ctx.setError(id, OK);
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [file, init, tests]);
+	}, [file, init, JSON.stringify(tests)]);
 
 	const onChange = useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
 		// :<

--- a/app/_components/Form.tsx
+++ b/app/_components/Form.tsx
@@ -181,7 +181,7 @@ Form.Input = function Input({
 		// you've made all the way through here..! congrats
 		ctx.setError(id, OK);
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [value, focus, tests, ctx.values]);
+	}, [value, focus, ctx.values, JSON.stringify(tests)]);
 
 	const self = useRef<HTMLDivElement>(null);
 
@@ -305,7 +305,7 @@ Form.TextArea = function TextArea({ id, init, tests, placeholder }: Readonly<{ i
 		// you've made all the way through here..! congrats
 		ctx.setError(id, OK);
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [value, focus, tests, ctx.values]);
+	}, [value, focus, ctx.values, JSON.stringify(tests)]);
 
 	const self = useRef<HTMLTextAreaElement>(null);
 
@@ -416,7 +416,7 @@ Form.ImageInput = function ImageInput({
 		// you've made all the way through here..! congrats
 		ctx.setError(id, OK);
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [file, init, tests]);
+	}, [file, init, JSON.stringify(tests)]);
 
 	const onChange = useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
 		// :<


### PR DESCRIPTION
## 연관된 이슈

close #16 

## 작업 내용

의존성 배열에 포함되어있는 tests를 deep compare 하지 않는 까닭에 유효성검사가 불필요하게 많이 처리되는 현상을 수정했어요

## 스크린샷

## 코멘트 및 논의 사항

리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
