### PR TITLE
♻️ refactor: 드롭다운 개선 사항 반영

### DIFF
--- a/app/(board)/boards/page.tsx
+++ b/app/(board)/boards/page.tsx
@@ -133,7 +133,7 @@ export default function Page() {
 				</div>
 				<hr className="my-[40px] border-border-primary" />
 				<div className="flex flex-col gap-[24px] text-2lg font-bold text-text-primary">
-					<div className="flex items-center justify-between">
+					<div className="flex items-center justify-between text-md font-normal">
 						게시글
 						<DropDown
 							gapY={6}

--- a/app/_components/Dropdown.tsx
+++ b/app/_components/Dropdown.tsx
@@ -160,7 +160,7 @@ export default function DropDown({ options, children, align = "LR", gapX = 0, ga
 							}`} // 배경색 변경
 							tabIndex={0}
 							ref={(el) => {
-								menuRefs.current[index] = el!; //index에 DOM 요소 참조를 저장
+								menuRefs.current[index] = el!; // index에 DOM 요소 참조를 저장
 							}}
 							onClick={(e) => handleOptionClick(e, option.onClick, close)}
 						>

--- a/app/_components/Dropdown.tsx
+++ b/app/_components/Dropdown.tsx
@@ -1,13 +1,13 @@
-"use client";
-
 /* eslint-disable jsx-a11y/click-events-have-key-events */
 /* eslint-disable jsx-a11y/no-static-element-interactions */
 /* eslint-disable jsx-a11y/no-noninteractive-tabindex */
 /* eslint-disable react/jsx-props-no-spreading */
 
+"use client";
+
 import React, { useRef, useEffect } from "react";
 import Image from "next/image";
-import { useRouter } from "next/navigation";
+import { useRouter, useParams } from "next/navigation";
 import KebabIcon from "@/public/icons/KebabIcon";
 import Popover from "./Popover";
 
@@ -20,6 +20,7 @@ type Option = {
 	image?: string;
 	content?: React.ReactNode;
 	options?: Option[];
+	groupId?: string;
 };
 
 export interface DropDownProps {
@@ -28,12 +29,17 @@ export interface DropDownProps {
 	align?: "LR" | "CC" | "RL" | "LL" | "RR";
 	gapX?: number;
 	gapY?: number;
+	groupId?: string; // groupId 추가
 }
 
-export default function DropDown({ options, children, align = "LR", gapX = 0, gapY = 0 }: DropDownProps) {
+export default function DropDown({ options, children, align = "LR", gapX = 0, gapY = 0, groupId }: DropDownProps) {
 	const menuRefs = useRef<HTMLDivElement[]>([]); // 메뉴 항목 참조 배열
 	const addButtonRef = useRef<HTMLButtonElement>(null); // 팀 추가 버튼 참조
 	const router = useRouter();
+	const { id: currentGroupId } = useParams(); // 현재 그룹 ID 가져오기
+
+	// groupId가 전달되지 않으면 currentGroupId를 사용
+	const currentId = groupId || currentGroupId;
 
 	// 키보드 이동 기능 추가
 	useEffect(() => {
@@ -119,6 +125,27 @@ export default function DropDown({ options, children, align = "LR", gapX = 0, ga
 		}
 	}
 
+	function renderEmptyState() {
+		return (
+			<div className="flex h-[142px] w-[218px] flex-col items-center justify-between rounded-[12px] bg-background-secondary p-[16px] text-[#F8FAFC]">
+				<div className="flex h-[46px] w-[186px] items-center justify-center">
+					<p>참여 중인 팀이 없습니다.</p>
+				</div>
+				<button
+					type="button"
+					ref={addButtonRef}
+					tabIndex={0}
+					className="mt-[16px] flex h-[48px] w-[186px] cursor-pointer items-center justify-center rounded-[12px] border text-[16px] hover:bg-[#63748D] focus:bg-[#475569] focus:outline-none"
+					onClick={() => {
+						router.push("/create-team");
+					}}
+				>
+					+ 팀 추가하기
+				</button>
+			</div>
+		);
+	}
+
 	function recursive(items: Option[], close: () => void) {
 		return (
 			<div className="flex w-max min-w-[120px] flex-col rounded-[12px] border border-white border-opacity-5 bg-background-secondary text-[#F8FAFC]">
@@ -128,16 +155,17 @@ export default function DropDown({ options, children, align = "LR", gapX = 0, ga
 					{items.map((option, index) => (
 						<div
 							key={`${option.text} ${index}` || index}
-							className="flex size-full items-center rounded-[8px] hover:bg-[#63748D] focus:bg-[#475569] focus:outline-none"
+							className={`flex size-full h-[46px] items-center rounded-[8px] hover:bg-[#63748D] focus:bg-[#475569] focus:outline-none ${
+								option.groupId === currentId && currentId ? "bg-[#475569]" : "bg-background-secondary"
+							}`} // 배경색 변경
 							tabIndex={0}
 							ref={(el) => {
-								menuRefs.current[index] = el!; // menuRefs.current[index]에 DOM 요소 참조를 저장
+								menuRefs.current[index] = el!; //index에 DOM 요소 참조를 저장
 							}}
 							onClick={(e) => handleOptionClick(e, option.onClick, close)}
 						>
 							<div className={`flex size-full items-center ${option.image ? "justify-start" : "justify-center"} gap-[12px]`}>
 								<button type="button" className="flex max-w-[220px] cursor-pointer items-center justify-start gap-2 p-[8px]">
-									{/* 이미지가 있는 경우 이미지를 렌더링 */}
 									{option.image && (
 										<div className="flex-shrink-0">
 											<Image src={option.image} alt={option.text || "empty"} width={32} height={32} />
@@ -146,7 +174,6 @@ export default function DropDown({ options, children, align = "LR", gapX = 0, ga
 									<p className="flex-grow truncate text-left">{option.text}</p>
 								</button>
 							</div>
-							{/* 하위 옵션이 있는 경우 Popover를 렌더링 */}
 							{option.options && option.options.length > 0 && (
 								<Popover
 									overlay={(subClose) =>
@@ -190,7 +217,7 @@ export default function DropDown({ options, children, align = "LR", gapX = 0, ga
 
 	return (
 		<div className="flex" onMouseUp={(event) => event.stopPropagation()} onMouseDown={(event) => event.stopPropagation()}>
-			<Popover overlay={(close) => recursive(options, close)} {...getPopoverOrigins()} gapX={gapX} gapY={gapY}>
+			<Popover overlay={(close) => (options.length > 0 ? recursive(options, close) : renderEmptyState())} {...getPopoverOrigins()} gapX={gapX} gapY={gapY}>
 				<div className="cursor-pointer">{children}</div>
 			</Popover>
 		</div>

--- a/app/_components/header.tsx
+++ b/app/_components/header.tsx
@@ -41,6 +41,7 @@ export default function Header() {
 			text: membership.group.name,
 			image: membership.group.image ?? "/icons/emptyImage.svg",
 			onClick: () => router.push(`/${membership.groupId}`),
+			groupId: String(membership.groupId), // 그룹 ID 추가
 		})) ?? []),
 	];
 
@@ -137,16 +138,14 @@ export default function Header() {
 						<nav className="hidden tablet:flex">
 							<ul className="flex items-center gap-10">
 								{/* 팀 선택 드롭다운 */}
-								{teamDropdown.length > 0 && (
-									<li>
-										<DropDown options={teamDropdown} gapY={10} align="LL">
-											<button type="button" className="flex items-center gap-[10px] text-lg font-medium">
-												{user?.memberships.find((membership) => membership.groupId === Number(params.id))?.group.name ?? "팀 선택"}
-												<Icon.ArrowDown width={16} height={16} />
-											</button>
-										</DropDown>
-									</li>
-								)}
+								<li>
+									<DropDown options={teamDropdown.length > 0 ? teamDropdown : []} gapY={10} align="LL">
+										<button type="button" className="flex items-center gap-[10px] text-lg font-medium">
+											{user?.memberships.find((membership) => membership.groupId === Number(params.id))?.group.name ?? "팀 선택"}
+											<Icon.ArrowDown width={16} height={16} />
+										</button>
+									</DropDown>
+								</li>
 								<li>
 									<Link href="/boards" className="text-lg font-medium">
 										자유게시판

--- a/app/_components/modal-contents/DeleteModal.tsx
+++ b/app/_components/modal-contents/DeleteModal.tsx
@@ -13,7 +13,7 @@ export default function DeleteModal({ onClick, close, modalName, modalContent }:
 		<ModalWrapper close={close}>
 			<div className="mx-auto min-w-[352px] font-medium">
 				<div className="mt-6 px-9">
-					<h1 className="overflow-hidden text-ellipsis whitespace-nowrap text-center">{`${modalName}을`}</h1>
+					{modalName ? <h1 className="overflow-hidden text-ellipsis whitespace-nowrap text-center">{`${modalName}을`}</h1> : null}
 					<h1 className="mt-2 max-w-full text-center text-lg">{modalContent}</h1>
 					<div className="mt-6 flex h-[47px] gap-2">
 						<Button variant="white" onClick={close}>


### PR DESCRIPTION
## 연관된 이슈


- clese #89 

## 작업 내용
- 접속한 팀 페이지에 맞게 버튼 배경색 변경
- 드롭다운 요소 최소 높이 설정. 이미지 크기에 따라 높이 달라지는 문제 해결 
- 자게 드롭다운 메뉴 폰트 일정하게 설정
- 팀이 없을 때 빈 메뉴 보여주고 팀 추가 버튼 볼 수 있도록 수정


## 스크린샷
<img src="https://github.com/user-attachments/assets/41c15702-8be5-4c02-b3a1-5cbd03e736b3" width="400px" >
<img src="https://github.com/user-attachments/assets/a2ba6e05-6c03-4fb5-893f-285cca1ffff7" width="400px" >


## 코멘트 및 논의 사항
놓친 부분 있다면 의견 부탁드립니다.