### PR TITLE
🐛 fix: 드롭다운 이벤트 리스너 제거 로직 수정

### DIFF
--- a/app/_components/Dropdown.tsx
+++ b/app/_components/Dropdown.tsx
@@ -5,7 +5,7 @@
 
 "use client";
 
-import React, { useRef, useEffect } from "react";
+import React, { useRef } from "react";
 import Image from "next/image";
 import { useRouter, useParams } from "next/navigation";
 import KebabIcon from "@/public/icons/KebabIcon";
@@ -29,7 +29,7 @@ export interface DropDownProps {
 	align?: "LR" | "CC" | "RL" | "LL" | "RR";
 	gapX?: number;
 	gapY?: number;
-	groupId?: string; // groupId 추가
+	groupId?: string;
 }
 
 export default function DropDown({ options, children, align = "LR", gapX = 0, gapY = 0, groupId }: DropDownProps) {
@@ -37,45 +37,40 @@ export default function DropDown({ options, children, align = "LR", gapX = 0, ga
 	const addButtonRef = useRef<HTMLButtonElement>(null); // 팀 추가 버튼 참조
 	const router = useRouter();
 	const { id: currentGroupId } = useParams(); // 현재 그룹 ID 가져오기
-
-	// groupId가 전달되지 않으면 currentGroupId를 사용
 	const currentId = groupId || currentGroupId;
 
 	// 키보드 이동 기능 추가
-	useEffect(() => {
-		const handleKeyDown = (event: KeyboardEvent) => {
-			const currentIndex = menuRefs.current.findIndex((ref) => ref === document.activeElement);
+	const handleKeyDown = (event: KeyboardEvent) => {
+		const currentIndex = menuRefs.current.findIndex((ref) => ref === document.activeElement);
 
-			if (event.key === "ArrowDown") {
-				// 아래로 이동
-				event.preventDefault();
-				if (currentIndex === menuRefs.current.length - 1) {
-					addButtonRef.current?.focus(); // 마지막 메뉴에서 버튼으로 이동
-				} else {
-					const nextIndex = (currentIndex + 1) % menuRefs.current.length;
-					menuRefs.current[nextIndex]?.focus();
-				}
-			} else if (event.key === "ArrowUp") {
-				// 위로 이동
-				event.preventDefault();
-				if (document.activeElement === addButtonRef.current) {
-					menuRefs.current[menuRefs.current.length - 1]?.focus(); // 버튼에서 마지막 메뉴로 이동
-				} else {
-					const prevIndex = (currentIndex - 1 + menuRefs.current.length) % menuRefs.current.length;
-					menuRefs.current[prevIndex]?.focus();
-				}
-			} else if (event.key === "Escape") {
-				// Escape 키로 메뉴 닫기
-				event.preventDefault();
-				menuRefs.current[currentIndex]?.blur();
+		if (event.key === "ArrowDown") {
+			// 아래로 이동
+			event.preventDefault();
+			if (currentIndex === menuRefs.current.length - 1) {
+				addButtonRef.current?.focus(); // 마지막 메뉴에서 버튼으로 이동
+			} else {
+				const nextIndex = (currentIndex + 1) % menuRefs.current.length;
+				menuRefs.current[nextIndex]?.focus();
 			}
-		};
+		} else if (event.key === "ArrowUp") {
+			// 위로 이동
+			event.preventDefault();
+			if (document.activeElement === addButtonRef.current) {
+				menuRefs.current[menuRefs.current.length - 1]?.focus(); // 버튼에서 마지막 메뉴로 이동
+			} else {
+				const prevIndex = (currentIndex - 1 + menuRefs.current.length) % menuRefs.current.length;
+				menuRefs.current[prevIndex]?.focus();
+			}
+		}
+	};
 
-		document.addEventListener("keydown", handleKeyDown);
-		return () => {
-			document.removeEventListener("keydown", handleKeyDown);
-		};
-	}, []);
+	const handleFocus = (index: number) => {
+		menuRefs.current[index]?.addEventListener("keydown", handleKeyDown);
+	};
+
+	const handleBlur = (index: number) => {
+		menuRefs.current[index]?.removeEventListener("keydown", handleKeyDown);
+	};
 
 	function handleOptionClick(e: React.MouseEvent, onClick?: () => void, close?: () => void) {
 		if (onClick) {
@@ -146,18 +141,22 @@ export default function DropDown({ options, children, align = "LR", gapX = 0, ga
 		return (
 			<div className="flex w-max min-w-[120px] flex-col rounded-[12px] border border-white border-opacity-5 bg-background-secondary shadow-teamDropdown">
 				<div
-					className={`flex max-h-[308px] flex-col overflow-y-auto scrollbar:w-2 scrollbar:bg-background-primary scrollbar-thumb:bg-background-tertiary ${items.some((option) => option.image) ? "mt-2 space-y-2 p-[16px]" : ""}`}
+					className={`flex max-h-[308px] flex-col overflow-y-auto scrollbar:w-2 scrollbar:bg-background-primary scrollbar-thumb:bg-background-tertiary ${
+						items.some((option) => option.image) ? "mt-2 space-y-2 p-[16px]" : ""
+					}`}
 				>
 					{items.map((option, index) => (
 						<div
 							key={`${option.text} ${index}` || index}
 							className={`flex size-full h-[46px] cursor-pointer items-center rounded-[8px] hover:bg-dropdown-hover focus:bg-dropdown-active focus:outline-none ${
 								option.groupId === currentId && currentId ? "bg-background-quaternary" : "bg-background-secondary"
-							}`} // 배경색 변경
+							}`}
 							tabIndex={0}
 							ref={(el) => {
 								menuRefs.current[index] = el!; // index에 DOM 요소 참조를 저장
 							}}
+							onFocus={() => handleFocus(index)} // 포커스가 잡히면 이벤트 리스너 추가
+							onBlur={() => handleBlur(index)} // 포커스를 잃으면 이벤트 리스너 제거
 							onClick={(e) => handleOptionClick(e, option.onClick, close)}
 						>
 							<div className={`flex size-full items-center ${option.image ? "justify-start" : "justify-center"} gap-[12px]`}>
@@ -190,7 +189,6 @@ export default function DropDown({ options, children, align = "LR", gapX = 0, ga
 						</div>
 					))}
 				</div>
-
 				{/* 배열의 끝에 이미지를 가진 옵션이 있을 경우, 스크롤 영역 바깥에 추가 버튼을 렌더링 */}
 				{items.some((option) => option.image) && (
 					<div className="flex size-full items-center justify-center gap-[12px]">


### PR DESCRIPTION
## 작업 내용

- [x] 전역적으로 민폐끼치는 드롭다운 수정


++)
사용자가 알기 쉽게 tab와 arrowDown으로 포커스 이동하게 수정했습니다. 민폐 이슈로 삭제된 enter 선택 기능도 추가했어요!

## 코멘트 및 논의 사항

포커스에 따라서 이벤트 로직 제거되게 수정했습니다. 확인하시고 승인 부탁드립니다.